### PR TITLE
wait_timeout should accept int|float

### DIFF
--- a/timeout_sampler/__init__.py
+++ b/timeout_sampler/__init__.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
+
 import datetime
 import time
 from typing import Any, Callable
+
 from simple_logger.logger import get_logger
 
 LOGGER = get_logger(name=__name__)
@@ -70,7 +72,7 @@ class TimeoutSampler:
 
     def __init__(
         self,
-        wait_timeout: int,
+        wait_timeout: int | float,
         sleep: int,
         func: Callable,
         exceptions_dict: dict[type[Exception], list[str]] | None = None,
@@ -222,7 +224,7 @@ class TimeoutWatch:
     of a given interval
     """
 
-    def __init__(self, timeout: int) -> None:
+    def __init__(self, timeout: int | float) -> None:
         self.timeout = timeout
         self.start_time = time.time()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced timeout configuration flexibility by supporting both integer and floating-point timeout values for `TimeoutSampler` and `TimeoutWatch` classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->