### PR TITLE
Support exit on any exception

### DIFF
--- a/tests/test_timeout_sampler.py
+++ b/tests/test_timeout_sampler.py
@@ -36,6 +36,13 @@ class TestTimeoutSampler:
             ),
             pytest.param(
                 {
+                    "init_exceptions_dict": {},
+                    "runtime_exception": ValueError(),
+                },
+                id="init_any_exception_raise_valueerror_with_no_msg",
+            ),
+            pytest.param(
+                {
                     "init_exceptions_dict": {
                         ValueError: ["allowed exception text"],
                     },

--- a/timeout_sampler/__init__.py
+++ b/timeout_sampler/__init__.py
@@ -100,7 +100,7 @@ class TimeoutSampler:
         self.func_kwargs = func_kwargs or {}
         self.print_log = print_log
         self.print_func_log = print_func_log
-        self.exceptions_dict = exceptions_dict or {Exception: []}
+        self.exceptions_dict = exceptions_dict if exceptions_dict is not None else {Exception: []}
 
     def _get_func_info(self, _func: Callable, type_: str) -> Any:
         # If func is partial function.


### PR DESCRIPTION
To exit on any exception user can send `exceptions_dict={}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Refined the logic for setting default configurations for the `exceptions_dict` attribute, ensuring clarity in initialization.
  
- **Tests**
  - Added a new test case to enhance coverage for exception handling scenarios within the `TimeoutSampler` class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->